### PR TITLE
BUGFIX: corrects canvas typo.

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,15 +1,15 @@
-import Canvas from './canvas';
-import Customizer from './pages/Customizer';
-import Home from './pages/Home';
+import CanvasModel from "./canvas";
+import Customizer from "./pages/Customizer";
+import Home from "./pages/Home";
 
 function App() {
-  return (
-    <main className="app transition-all ease-in">
-      <Home />
-      <Canvas />
-      <Customizer />
-    </main>
-  )
+    return (
+        <main className="app transition-all ease-in">
+            <Home />
+            <CanvasModel />
+            <Customizer />
+        </main>
+    );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
in `client/src/canvas/index.jsx` is exported `CanvasModel` but in `client/src/App.jsx` is imported Canvas instead of CanvasModel from client/src/canvas