### PR TITLE
'toggle'

### DIFF
--- a/client/src/pages/Customizer.jsx
+++ b/client/src/pages/Customizer.jsx
@@ -24,6 +24,8 @@ const Customizer = () => {
     stylishShirt: false,
   })
 
+   const [isopen, setIsopen] = useState(false);
+
   // show tab content depending on the activeTab
   const generateTabContent = () => {
     switch (activeEditorTab) {
@@ -131,7 +133,12 @@ const Customizer = () => {
                   <Tab 
                     key={tab.name}
                     tab={tab}
-                    handleClick={() => setActiveEditorTab(tab.name)}
+                    handleClick={() => {
+                       setIsopen(!isopen)
+                        if(!isopen){
+                        setActiveEditorTab(tab.name)
+                      }else{setActiveEditorTab("")}
+                    }}
                   />
                 ))}
 


### PR DESCRIPTION
I added a new feature that toggles the editor tab contents(filepicker, colorpicker and aipicker) on and off on click. I discovered for example when the colorpicker is selected on mobile device after a different color is picked, the colorpicker still covers part of the model thereby preventing full visualization. Thanks for going through my little contribution.