### PR TITLE
Update Shirt.jsx

### DIFF
--- a/client/src/canvas/Shirt.jsx
+++ b/client/src/canvas/Shirt.jsx
@@ -41,7 +41,6 @@ const Shirt = () => {
             rotation={[0, 0, 0]}
             scale={0.15}
             map={logoTexture}
-            map-anisotropy={16}
             depthTest={false}
             depthWrite={true}
           />


### PR DESCRIPTION
Currently, the code line `map-anisotropy={16}` introduces a major bug that prevents the app from running. The app is only usable if this line is removed.